### PR TITLE
VE 1.0.8

### DIFF
--- a/libs/fm_factory/fm_factory.h
+++ b/libs/fm_factory/fm_factory.h
@@ -16,6 +16,21 @@
 
 // Typedef.
 
+typedef enum
+{
+    RES_0, RES_1, RES_2, RES_3
+} sel_resolution_t;
+
+typedef enum
+{
+    DIG_0, DIG_1, DIG_2, DIG_3, DIG_4, DIG_5, DIG_6, DIG_7
+} sel_digit_t;
+
+typedef enum
+{
+    VAL_0, VAL_1, VAL_2, VAL_3, VAL_4, VAL_5, VAL_6, VAL_7, VAL_8, VAL_9
+} sel_value_t;
+
 // Defines.
 
 // Function prototypes
@@ -26,8 +41,13 @@ fmc_totalizer_t fm_factory_get_rate();
 fmc_temp_t fm_factory_get_temp();
 fmc_fp_t fm_factory_get_units_digits();
 fmc_fp_t fm_factory_get_k_factor();
-void fm_factory_modify_res(uint8_t units_res, uint8_t acm_res, uint8_t ttl_res,
-uint8_t rate_res);
+void fm_factory_modify_k_factor_add(sel_digit_t digit_k);
+void fm_factory_modify_k_factor_subs(sel_digit_t digit_k);
+void fm_factory_modify_res_acm_ttl(sel_resolution_t units_res,
+sel_resolution_t acm_res, sel_resolution_t ttl_res);
+void fm_factory_modify_time_units(fmc_unit_time_t time_units);
+void fm_factory_modify_volume_units(fmc_unit_volume_t volume_units);
+void fm_factory_separate_k_factor();
 
 #endif /* FM_FACTORY_H */
 

--- a/libs/fm_lcd/fm_lcd.c
+++ b/libs/fm_lcd/fm_lcd.c
@@ -339,7 +339,7 @@ void fm_lcd_k_factor()
 {
     char lcd_msg[PCF8553_DATA_SIZE];
 
-    fm_lcd_fp_to_str(fm_factory_get_k_factor(), ' ', LINE_0_DIGITS, lcd_msg,
+    fm_lcd_fp_to_str(fm_factory_get_k_factor(), '0', LINE_0_DIGITS, lcd_msg,
     sizeof(lcd_msg));
     fm_lcd_fp_add_dot(fm_factory_get_k_factor(), lcd_msg, sizeof(lcd_msg));
     fm_lcd_puts(lcd_msg, HIGH_ROW);

--- a/libs/fm_lcd/lcd.c
+++ b/libs/fm_lcd/lcd.c
@@ -780,7 +780,7 @@ void lcd_set_time_unit(fmc_unit_time_t time_unit, blink_t blink_speed)
 
 void lcd_set_vol_unit(fmc_unit_volume_t vol_unit, blink_t blink_speed)
 {
-    switch(vol_unit)
+    switch (vol_unit)
     {
         case LT:
             g_lcd_map[REG_15] |= (1 << BIT_5);

--- a/libs/fm_menu_config/fm_menu_config.c
+++ b/libs/fm_menu_config/fm_menu_config.c
@@ -174,6 +174,7 @@ ptr_ret_menu_t fm_menu_config_k_param(fm_event_t event_id)
 {
     static uint8_t new_entry = 1;
     static uint8_t new_exit = 0;
+    static sel_digit_t digit_modify = DIG_0;
 
     ptr_ret_menu_t ret_menu = (ptr_ret_menu_t) fm_menu_config_k_param;
     fm_event_t event_now;
@@ -190,10 +191,59 @@ ptr_ret_menu_t fm_menu_config_k_param(fm_event_t event_id)
     switch (event_id)
     {
         case EVENT_KEY_UP:
+            if (correct_password)
+            {
+                fm_factory_modify_k_factor_add(digit_modify);
+            }
+            event_now = EVENT_LCD_REFRESH;
+            osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;
         case EVENT_KEY_DOWN:
+            if (correct_password)
+            {
+                fm_factory_modify_k_factor_subs(digit_modify);
+            }
+            event_now = EVENT_LCD_REFRESH;
+            osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;
         case EVENT_KEY_ENTER:
+            if (correct_password)
+            {
+                if (digit_modify == DIG_0)
+                {
+                    digit_modify = DIG_1;
+                }
+                else if (digit_modify == DIG_1)
+                {
+                    digit_modify = DIG_2;
+                }
+                else if (digit_modify == DIG_2)
+                {
+                    digit_modify = DIG_3;
+                }
+                else if (digit_modify == DIG_3)
+                {
+                    digit_modify = DIG_4;
+                }
+                else if (digit_modify == DIG_4)
+                {
+                    digit_modify = DIG_5;
+                }
+                else if (digit_modify == DIG_5)
+                {
+                    digit_modify = DIG_6;
+                }
+                else if (digit_modify == DIG_6)
+                {
+                    digit_modify = DIG_7;
+                }
+                else if (digit_modify == DIG_7)
+                {
+                    digit_modify = DIG_0;
+                }
+            }
+            event_now = EVENT_LCD_REFRESH;
+            osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;
         case EVENT_KEY_ESC:
             new_exit = 1;
@@ -529,27 +579,81 @@ ptr_ret_menu_t fm_menu_config_units(fm_event_t event_id)
     switch (event_id)
     {
         case EVENT_KEY_UP:
+            if (correct_password)
+            {
+                if (fm_factory_get_acm().unit_volume == LT)
+                {
+                    fm_factory_modify_volume_units(M3);
+                }
+                else if (fm_factory_get_acm().unit_volume == M3)
+                {
+                    fm_factory_modify_volume_units(KG);
+                }
+                else if (fm_factory_get_acm().unit_volume == KG)
+                {
+                    fm_factory_modify_volume_units(GL);
+                }
+                else if (fm_factory_get_acm().unit_volume == GL)
+                {
+                    fm_factory_modify_volume_units(BR);
+                }
+                else if (fm_factory_get_acm().unit_volume == BR)
+                {
+                    fm_factory_modify_volume_units(NOTHING);
+                }
+                else if (fm_factory_get_acm().unit_volume == NOTHING)
+                {
+                    fm_factory_modify_volume_units(LT);
+                }
+                fm_lcd_clear();
+            }
+            event_now = EVENT_LCD_REFRESH;
+            osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;
         case EVENT_KEY_DOWN:
+            if (correct_password)
+            {
+                if (fm_factory_get_acm().unit_time == H)
+                {
+                    fm_factory_modify_time_units(D);
+                }
+                else if (fm_factory_get_acm().unit_time == D)
+                {
+                    fm_factory_modify_time_units(S);
+                }
+                else if (fm_factory_get_acm().unit_time == S)
+                {
+                    fm_factory_modify_time_units(M);
+                }
+                else if (fm_factory_get_acm().unit_time == M)
+                {
+                    fm_factory_modify_time_units(H);
+                }
+                fm_lcd_clear();
+            }
+            event_now = EVENT_LCD_REFRESH;
+            osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;
         case EVENT_KEY_ENTER:
-            if(fm_factory_get_units_digits().res == 0)
+            if (correct_password)
             {
-                fm_factory_modify_res(1, 1, 1, 1);
+                if (fm_factory_get_units_digits().res == RES_0)
+                {
+                    fm_factory_modify_res_acm_ttl(RES_1, RES_1, RES_1);
+                }
+                else if (fm_factory_get_units_digits().res == RES_1)
+                {
+                    fm_factory_modify_res_acm_ttl(RES_2, RES_2, RES_2);
+                }
+                else if (fm_factory_get_units_digits().res == RES_2)
+                {
+                    fm_factory_modify_res_acm_ttl(RES_3, RES_3, RES_3);
+                }
+                else if (fm_factory_get_units_digits().res == RES_3)
+                {
+                    fm_factory_modify_res_acm_ttl(RES_0, RES_0, RES_0);
+                }
             }
-            else if(fm_factory_get_units_digits().res == 1)
-            {
-                fm_factory_modify_res(2, 2, 2, 2);
-            }
-            else if(fm_factory_get_units_digits().res == 2)
-            {
-                fm_factory_modify_res(3, 3, 3, 3);
-            }
-            else if(fm_factory_get_units_digits().res == 3)
-            {
-                fm_factory_modify_res(0, 0, 0, 0);
-            }
-
             event_now = EVENT_LCD_REFRESH;
             osMessageQueuePut(h_event_queue, &event_now, 0, 0);
         break;

--- a/libs/fm_version/fm_version.c
+++ b/libs/fm_version/fm_version.c
@@ -30,7 +30,7 @@
 // Defines.
 #define VERSION     1
 #define REVISION    0
-#define RELEASE     7
+#define RELEASE     8
 
 //Debug.
 

--- a/libs/fmc/fmc.h
+++ b/libs/fmc/fmc.h
@@ -48,22 +48,12 @@ typedef enum
 
 typedef enum
 {
-    LT,
-    M3,
-    KG,
-    GL,
-    BR,
-    CELSIUS,
-    NOTHING
+    LT, M3, KG, GL, BR, CELSIUS, NOTHING
 } fmc_unit_volume_t;
 
 typedef enum
 {
-    H,
-    D,
-    S,
-    M,
-    UNIT_TIME_END
+    H, D, S, M, UNIT_TIME_END
 } fmc_unit_time_t;
 
 // Typedef.
@@ -94,7 +84,7 @@ typedef struct
 // Function prototypes
 
 fmc_totalizer_t fmc_get_acm();
-fmc_temp_t      fmc_get_stm32_temp();
+fmc_temp_t fmc_get_stm32_temp();
 fmc_totalizer_t fmc_get_rate();
 fmc_totalizer_t fmc_get_ttl();
 uint32_t fmc_get_version();

--- a/stm32cubeide_preferences/user_defined_dictionary_esp.lst
+++ b/stm32cubeide_preferences/user_defined_dictionary_esp.lst
@@ -87985,3 +87985,6 @@ medidas
 terminan
 envian
 microcontrolador
+factores
+modifica
+separa


### PR DESCRIPTION
Ahora se puede modificar el factor K de calibración y las unidades de volumen y tiempo, en adición a la resolución de los factores ttl y acm que ya podía cambiarse en el commit anterior. Ahora la contraseña ingresada debe ser obligatoriamente correcta para poder hacer modificaciones (DOWN UP UP ENTER).